### PR TITLE
Use camel case instead of snake case

### DIFF
--- a/code/02/pointers.go
+++ b/code/02/pointers.go
@@ -5,11 +5,11 @@ import "fmt"
 var (
 	name   string = "Чочко"
 	age    uint8  = 27
-	p_name *string
+	pName *string
 )
 
 func main() {
-	p_name = &name
-	fmt.Printf("name е на адрес %p и има стойност %s\n", p_name, name)
+	pName = &name
+	fmt.Printf("name е на адрес %p и има стойност %s\n", pName, name)
 	fmt.Printf("age е на адрес %p и има стойност %d\n", &age, age)
 }


### PR DESCRIPTION
There were variable names in snake case in one of the examples.
