### PR TITLE
Add improvements to styles.css for slides

### DIFF
--- a/assets/static/styles.css
+++ b/assets/static/styles.css
@@ -439,3 +439,51 @@ div.output .buttons {
   left: -5px;
   top: -5px;
 }
+
+/* Media queries */
+
+@media (max-width: 1222px) {
+  .slides > article.current {
+    width: 90%;
+    margin-left: 5%;
+    left: 0px;
+    padding: 3% 5%;
+    font-size: 24px;
+  }
+  
+  .slide-area {
+    width: 5%;
+    margin: 0;
+  }
+  #prev-slide-area {
+    left: 0;
+  }
+  #next-slide-area {
+    right: 0;
+    left: auto;
+  }
+}
+
+@media (max-width: 1100px) {
+  .slides > article.current {
+    font-size: 22px;
+  }
+}
+
+@media (max-width: 1000px) {
+  .slides > article.current {
+    font-size: 21px;
+  }
+}
+
+@media (max-width: 900px) {
+  .slides > article.current {
+    font-size: 20px;
+  }
+}
+
+@media (max-width: 800px) {
+  .slides > article.current {
+    font-size: 19px;
+  }
+}


### PR DESCRIPTION
Make slides appear correctly when window height is below 700px;
Make .slide-areas appear correctly and be wide exactly how they are visible (not 50px wider);
Make slides be able to scroll if content is too big.
