### PR TITLE
Fix switch - case indentation in the examples

### DIFF
--- a/04-types_and_interfaces.slide
+++ b/04-types_and_interfaces.slide
@@ -86,12 +86,12 @@ http://fmi.golang.bg/
 
     func Abs(i integer) integer {
         switch {
-            case i < 0:
-                return -i
-            case i == 0:
-                return 0
-            default:
-                return i
+        case i < 0:
+            return -i
+        case i == 0:
+            return 0
+        default:
+            return i
         }
     }
 
@@ -106,12 +106,12 @@ http://fmi.golang.bg/
 
     func (i integer) Abs() integer {
         switch {
-            case i < 0:
-                return -i
-            case i == 0:
-                return 0
-            default:
-                return i
+        case i < 0:
+            return -i
+        case i == 0:
+            return 0
+        default:
+            return i
         }
     }
 


### PR DESCRIPTION
`case` should be on the same level as `switch`.
Also in the presentation the indentation is a mix of 4 spaces, 8 spaces and tabs, but the `switch` - `case` is the only easily visually recognizable error.
